### PR TITLE
Updates our custom line item handler

### DIFF
--- a/lib/active_merchant/billing/gateways/cyber_source.rb
+++ b/lib/active_merchant/billing/gateways/cyber_source.rb
@@ -434,11 +434,11 @@ module ActiveMerchant #:nodoc:
         if options[:line_items]
           options[:line_items].each_with_index do |value, index|
             xml.tag! 'item', {'id' => index} do
-              xml.tag! 'unitPrice', amount(value[:declared_value])
+              xml.tag! 'unitPrice', localized_amount(value[:declared_value].to_i, options[:currency] || default_currency)
               xml.tag! 'quantity', value[:quantity]
               xml.tag! 'productName', value[:description]
               xml.tag! 'productSKU', value[:sku]
-              xml.tag! 'taxAmount', amount(value[:tax_amount])
+              xml.tag! 'taxAmount', localized_amount(value[:tax_amount].to_i, options[:currency] || default_currency)
             end
           end
         end


### PR DESCRIPTION
The cybersource gateway was updated a while back to use `localized_amount`, so this change updates our custom line item handler for consistency.

A note on upgrading: I've merged in all of the updates from ActiveMerchant up to version 1.77.0, but left our customizations for line items and merchant descriptors.  **Do not specify a version in your Gemfile, as it won't pick up this newest change.**  I'll tag a release when I merge this in and a simple `bundle update activemerchant` should pick it up -- but please double-check the commit in the Gemfile.lock points to the newest master-branch commit/tag release.

This version of ActiveMerchant is v1.77.0.